### PR TITLE
Fix module path casing and update three.js color space usage

### DIFF
--- a/vite-project/src/Experience/experience.js
+++ b/vite-project/src/Experience/experience.js
@@ -7,7 +7,7 @@ import Renderer from './renderer.js';
 import World from '../World/world.js';
 import Resources from '../Utils/resources.js';
 import assets from '../Utils/assets.js';
-import Preloader from './Preloader.js';
+import Preloader from './preloader.js';
 
 import Controls from '../World/controls.js';
 

--- a/vite-project/src/Experience/renderer.js
+++ b/vite-project/src/Experience/renderer.js
@@ -19,7 +19,9 @@ export default class Renderer{
             antialias: true,
         });
         this.renderer.physicallyCorrectLights = true;
-        this.renderer.outputEncoding = THREE.sRGBEncoding;
+        // three.js r172 removed `sRGBEncoding` in favor of color spaces
+        // Use `outputColorSpace` with `SRGBColorSpace` to ensure correct colors
+        this.renderer.outputColorSpace = THREE.SRGBColorSpace;
         this.renderer.toneMapping = THREE.CineonToneMapping;
         this.renderer.toneMappingExposure = 1.75;
         this.renderer.shadowMap.enabled = true;

--- a/vite-project/src/Utils/resources.js
+++ b/vite-project/src/Utils/resources.js
@@ -48,7 +48,8 @@ export default class Resources extends EventEmitter{
             this.videoTexture[asset.name].minFilter = THREE.NearestFilter;
             this.videoTexture[asset.name].magFilter = THREE.NearestFilter;
             this.videoTexture[asset.name].generateMipmaps = false;
-            this.videoTexture[asset.name].encoding = THREE.sRGBEncoding;
+            // Use the new colorSpace API for video textures
+            this.videoTexture[asset.name].colorSpace = THREE.SRGBColorSpace;
 
             this.singleAssetLoaded(asset, this.videoTexture[asset.name]);
         }

--- a/vite-project/src/World/world.js
+++ b/vite-project/src/World/world.js
@@ -2,7 +2,7 @@ import Experience from "../Experience/experience";
 import Room from "./room";
 import Environment from "./environment";
 import Controls from "./controls";
-import Floor from "./Floor";
+import Floor from "./floor";
 import EventEmitter from "events";
 
 export default class World extends EventEmitter{


### PR DESCRIPTION
## Summary
- fix case-sensitive imports for `floor` and `preloader` modules
- update three.js color handling to use `SRGBColorSpace` and `outputColorSpace`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6895423ce908832996e9c2d07fc8299d